### PR TITLE
Disable host check

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,6 +38,7 @@ module.exports = {
     }),
   ],
   devServer: {
+    disableHostCheck: true,
     contentBase: './dist',
     hot: true,
     host: '0.0.0.0',


### PR DESCRIPTION
Fixes an error about "Invalid Host header"
Note: this is probably insecure if using this server
for a production system.