### PR TITLE
Use an external payer for transaction fees

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,20 +24,20 @@ $ npm install
 ```
 
 ### Select a Network
-The example connects to a local Solana network by default.
+The example connects to a local Solana cluster by default.
 
-To start a local Solana network run:
+To start a local Solana cluster run:
 ```bash
 $ npx solana-localnet update
 $ npm run localnet:up
 ```
 
-Solana network logs are available with:
+Solana cluster logs are available with:
 ```bash
-$ npx solana-localnet logs -f
+$ npm run localnet:logs
 ```
 
-For more details on working with a local network, see the [full instructions](https://github.com/solana-labs/solana-web3.js#local-network).
+For more details on working with a local cluster, see the [full instructions](https://github.com/solana-labs/solana-web3.js#local-network).
 
 Alternatively to connect to the public testnet, `export LIVE=1` in your
 environment.  By default `LIVE=1` will connect to the

--- a/package-lock.json
+++ b/package-lock.json
@@ -137,9 +137,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.4.tgz",
-      "integrity": "sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.5.tgz",
+      "integrity": "sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==",
       "requires": {
         "regenerator-runtime": "^0.13.2"
       },
@@ -267,9 +267,9 @@
       "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
     },
     "@solana/web3.js": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-0.15.4.tgz",
-      "integrity": "sha512-2WkYJmbBzypZTM00beoNKyi4SeKePs40dT6VBJC1HaqhsgySxb5/4KdbZX53MqiUqxAbdLHR2A3metmCQlsG3Q==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-0.15.6.tgz",
+      "integrity": "sha512-n98fYfb3mqByaA3eCHEulalWZzZi2dvzxi3/2bxGuaZA+z1Woya0+ZnSqCAWrOyIXkKtpsXrfkNQmk11tZjJ/w==",
       "requires": {
         "@babel/runtime": "^7.3.1",
         "bn.js": "^4.11.8",
@@ -282,7 +282,7 @@
         "rpc-websockets": "^4.3.3",
         "superstruct": "^0.6.0",
         "tweetnacl": "^1.0.0",
-        "ws": "^6.1.0"
+        "ws": "^7.0.0"
       }
     },
     "@types/events": {
@@ -2055,7 +2055,7 @@
     },
     "cheerio": {
       "version": "0.22.0",
-      "resolved": "http://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
       "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
       "requires": {
         "css-select": "~1.2.0",
@@ -2518,7 +2518,7 @@
     },
     "css-select": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "requires": {
         "boolbase": "~1.0.0",
@@ -2583,7 +2583,7 @@
     },
     "deep-eql": {
       "version": "0.1.3",
-      "resolved": "http://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
       "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
       "requires": {
         "type-detect": "0.1.1"
@@ -4170,8 +4170,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "optional": true
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "aproba": {
           "version": "1.2.0",
@@ -4192,14 +4191,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "optional": true
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4213,20 +4210,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "optional": true
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "optional": true
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "optional": true
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4342,8 +4336,7 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "optional": true
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
           "version": "1.3.5",
@@ -4355,7 +4348,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4370,7 +4362,6 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4483,8 +4474,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "optional": true
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4496,7 +4486,6 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4618,7 +4607,6 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4638,7 +4626,6 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4667,8 +4654,7 @@
         "wrappy": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "optional": true
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "yallist": {
           "version": "3.0.2",
@@ -4745,7 +4731,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "optional": true,
       "requires": {
         "is-glob": "^2.0.0"
       }
@@ -5001,9 +4986,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
-          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -5764,8 +5749,7 @@
     "is-extglob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-      "optional": true
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
     },
     "is-finite": {
       "version": "1.0.2",
@@ -5784,7 +5768,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "optional": true,
       "requires": {
         "is-extglob": "^1.0.0"
       }
@@ -6446,7 +6429,6 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
-      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -6704,7 +6686,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "optional": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
       }
@@ -9741,8 +9722,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -9760,13 +9740,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -9779,18 +9757,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -9893,8 +9868,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -9904,7 +9878,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -9917,20 +9890,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -9947,7 +9917,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -10020,8 +9989,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -10031,7 +9999,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -10107,8 +10074,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -10138,7 +10104,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -10156,7 +10121,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -10195,13 +10159,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -11185,8 +11147,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -11204,13 +11165,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -11223,18 +11182,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -11337,8 +11293,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -11348,7 +11303,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -11361,7 +11315,6 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -11464,8 +11417,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -11475,7 +11427,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -11582,7 +11533,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -11600,7 +11550,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -11639,8 +11588,7 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
@@ -12038,11 +11986,11 @@
       }
     },
     "ws": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-      "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.0.0.tgz",
+      "integrity": "sha512-cknCal4k0EAOrh1SHHPPWWh4qm93g1IuGGGwBjWkXmCG7LsDtL8w9w+YVfaF+KSVwiHQKDIMsSLBVftKf9d1pg==",
       "requires": {
-        "async-limiter": "~1.0.0"
+        "async-limiter": "^1.0.0"
       }
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "prettier": "^1.14.3"
   },
   "dependencies": {
-    "@solana/web3.js": "0.15.5",
+    "@solana/web3.js": "0.15.6",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
     "babel-eslint": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "prettier": "^1.14.3"
   },
   "dependencies": {
-    "@solana/web3.js": "0.15.4",
+    "@solana/web3.js": "0.15.5",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
     "babel-eslint": "^10.0.1",

--- a/src/program/tic-tac-toe-dashboard.js
+++ b/src/program/tic-tac-toe-dashboard.js
@@ -72,7 +72,10 @@ export class TicTacToeDashboard {
   ): Promise<TicTacToeDashboard> {
     const lamports = 10000;
     const fee = 10; // TODO: use FeeCalculator to properly account for the transaction fee
-    const tempAccount = await newSystemAccountWithAirdrop(connection, lamports + fee);
+    const tempAccount = await newSystemAccountWithAirdrop(
+      connection,
+      lamports + fee,
+    );
 
     const dashboardAccount = new Account();
 
@@ -166,7 +169,17 @@ export class TicTacToeDashboard {
       programId: this.programId,
       data: ProgramCommand.initPlayer(),
     });
-    transaction.signPartial(this._dashboardAccount, playerPublicKey);
+
+    const payerAccount = await newSystemAccountWithAirdrop(
+      this.connection,
+      10, // TODO: use FeeCalculator to properly account for the transaction fee
+    );
+
+    transaction.signPartial(
+      payerAccount,
+      this._dashboardAccount,
+      playerPublicKey,
+    );
     return transaction;
   }
 

--- a/src/program/tic-tac-toe-dashboard.js
+++ b/src/program/tic-tac-toe-dashboard.js
@@ -87,7 +87,7 @@ export class TicTacToeDashboard {
       programId,
     );
     transaction.add({
-      keys: [{pubkey: dashboardAccount.publicKey, isSigner: true}],
+      keys: [{pubkey: dashboardAccount.publicKey, isSigner: true, isDebitable: true}],
       programId,
       data: ProgramCommand.initDashboard(),
     });
@@ -163,8 +163,8 @@ export class TicTacToeDashboard {
     let transaction = new Transaction({recentBlockhash});
     transaction.add(SystemProgram.assign(playerPublicKey, this.programId), {
       keys: [
-        {pubkey: this._dashboardAccount.publicKey, isSigner: true},
-        {pubkey: playerPublicKey, isSigner: true},
+        {pubkey: this._dashboardAccount.publicKey, isSigner: true, isDebitable: true},
+        {pubkey: playerPublicKey, isSigner: true, isDebitable: true},
       ],
       programId: this.programId,
       data: ProgramCommand.initPlayer(),
@@ -261,9 +261,9 @@ export class TicTacToeDashboard {
         );
         const transaction = new Transaction().add({
           keys: [
-            {pubkey: playerAccount.publicKey, isSigner: true},
-            {pubkey: this.publicKey, isSigner: false},
-            {pubkey: myGame.gamePublicKey, isSigner: false},
+            {pubkey: playerAccount.publicKey, isSigner: true, isDebitable: true},
+            {pubkey: this.publicKey, isSigner: false, isDebitable: true},
+            {pubkey: myGame.gamePublicKey, isSigner: false, isDebitable: true},
           ],
           programId: this.programId,
           data: ProgramCommand.advertiseGame(),

--- a/src/program/tic-tac-toe.js
+++ b/src/program/tic-tac-toe.js
@@ -141,9 +141,9 @@ export class TicTacToe {
     );
     transaction.add({
       keys: [
-        {pubkey: gameAccount.publicKey, isSigner: true},
-        {pubkey: dashboard, isSigner: true},
-        {pubkey: playerXAccount.publicKey, isSigner: true},
+        {pubkey: gameAccount.publicKey, isSigner: true, isDebitable: true},
+        {pubkey: dashboard, isSigner: true, isDebitable: true},
+        {pubkey: playerXAccount.publicKey, isSigner: true, isDebitable: true},
       ],
       programId,
       data: ProgramCommand.initGame(),
@@ -191,9 +191,9 @@ export class TicTacToe {
     {
       const transaction = new Transaction().add({
         keys: [
-          {pubkey: playerOAccount.publicKey, isSigner: true},
-          {pubkey: dashboard, isSigner: false},
-          {pubkey: gamePublicKey, isSigner: false},
+          {pubkey: playerOAccount.publicKey, isSigner: true, isDebitable: true},
+          {pubkey: dashboard, isSigner: false, isDebitable: true},
+          {pubkey: gamePublicKey, isSigner: false, isDebitable: true},
         ],
         programId,
         data: ProgramCommand.joinGame(),
@@ -226,9 +226,9 @@ export class TicTacToe {
   async keepAlive(): Promise<void> {
     const transaction = new Transaction().add({
       keys: [
-        {pubkey: this.playerAccount.publicKey, isSigner: true},
-        {pubkey: this.dashboard, isSigner: false},
-        {pubkey: this.gamePublicKey, isSigner: false},
+        {pubkey: this.playerAccount.publicKey, isSigner: true, isDebitable: true},
+        {pubkey: this.dashboard, isSigner: false, isDebitable: true},
+        {pubkey: this.gamePublicKey, isSigner: false, isDebitable: true},
       ],
       programId: this.programId,
       data: ProgramCommand.keepAlive(),
@@ -254,9 +254,9 @@ export class TicTacToe {
   async move(x: number, y: number): Promise<void> {
     const transaction = new Transaction().add({
       keys: [
-        {pubkey: this.playerAccount.publicKey, isSigner: true},
-        {pubkey: this.dashboard, isSigner: false},
-        {pubkey: this.gamePublicKey, isSigner: false},
+        {pubkey: this.playerAccount.publicKey, isSigner: true, isDebitable: true},
+        {pubkey: this.dashboard, isSigner: false, isDebitable: true},
+        {pubkey: this.gamePublicKey, isSigner: false, isDebitable: true},
       ],
       programId: this.programId,
       data: ProgramCommand.move(x, y),

--- a/src/util/send-and-confirm-transaction.js
+++ b/src/util/send-and-confirm-transaction.js
@@ -4,6 +4,8 @@ import {sendAndConfirmTransaction as realSendAndConfirmTransaction} from '@solan
 import type {Account, Connection, Transaction} from '@solana/web3.js';
 import YAML from 'json-to-pretty-yaml';
 
+import {newSystemAccountWithAirdrop} from './new-system-account-with-airdrop';
+
 type TransactionNotification = (string, string) => void;
 
 let notify: TransactionNotification = () => undefined;
@@ -11,6 +13,8 @@ let notify: TransactionNotification = () => undefined;
 export function onTransaction(callback: TransactionNotification) {
   notify = callback;
 }
+
+let payerAccount: Account | null = null;
 
 export async function sendAndConfirmTransaction(
   title: string,
@@ -20,9 +24,14 @@ export async function sendAndConfirmTransaction(
 ): Promise<void> {
   const when = Date.now();
 
+  if (payerAccount === null) {
+    payerAccount = await newSystemAccountWithAirdrop(connection, 1000);
+  }
+
   const signature = await realSendAndConfirmTransaction(
     connection,
     transaction,
+    payerAccount,
     ...signers,
   );
 


### PR DESCRIPTION
As of Solana 0.15.0, only system accounts may be used to pay for transactions.  This patch is a temporary workaround to keep tic-tac-toe working until the example can be fully restructured to account for this new requirement on fees
